### PR TITLE
Don't hard code user name in test

### DIFF
--- a/test/aws_ssm_provider_test.exs
+++ b/test/aws_ssm_provider_test.exs
@@ -35,7 +35,7 @@ defmodule AwsSsmProviderTest do
       nested_duplicate_string: "dup_string_4",
       nested_duplicate_integer: 4,
       nested_duplicate_regex: ~r/(\d{3}.csv)/,
-      nested_duplicate_system_var: "erikosmond",
+      nested_duplicate_system_var: System.get_env("USER"),
       nested_duplicate_json_array: [9, 2, 2]
     ]
   end


### PR DESCRIPTION
When I tried to run the tests, they failed due to the hard-coded user. This fixed it for me.